### PR TITLE
Define a integration type

### DIFF
--- a/custom_components/alphaess_modbus/manifest.json
+++ b/custom_components/alphaess_modbus/manifest.json
@@ -4,6 +4,7 @@
   "codeowners": ["@senalse"],
   "config_flow": true,
   "documentation": "https://github.com/senalse/ha-alphaess-modbus",
+  "integration_type": "device",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/senalse/ha-alphaess-modbus/issues",
   "requirements": ["pymodbus>=3.7.4"],


### PR DESCRIPTION
By default, when a integration type is not defined, its set to a hub, for a integration such as this, it isnt the best idea

it should be set to the device type

[https://developers.home-assistant.io/docs/creating_integration_manifest/#integration-type](https://developers.home-assistant.io/docs/creating_integration_manifest/#integration-type)